### PR TITLE
feat: integrate character system with S3 images, ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ npm-debug.log*
 
 # Claude Code
 .claude/launch.json
+
+# Internal docs
+SDD*.md
+contexto_front.md

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { CharacterService } from './core/services/character.service';
 
 @Component({
   selector: 'app-root',
@@ -7,4 +8,10 @@ import { RouterOutlet } from '@angular/router';
   imports: [RouterOutlet],
   templateUrl: './app.component.html',
 })
-export class AppComponent {}
+export class AppComponent implements OnInit {
+  private characterService = inject(CharacterService);
+
+  async ngOnInit(): Promise<void> {
+    await this.characterService.load();
+  }
+}

--- a/src/app/core/auth/services/auth.service.ts
+++ b/src/app/core/auth/services/auth.service.ts
@@ -1,9 +1,7 @@
 import { Injectable, computed, signal } from '@angular/core';
 import {
   CognitoIdentityProviderClient,
-  ConfirmForgotPasswordCommand,
   ConfirmSignUpCommand,
-  ForgotPasswordCommand,
   GetUserCommand,
   GlobalSignOutCommand,
   InitiateAuthCommand,
@@ -91,26 +89,6 @@ export class AuthService {
     const token = this.getAccessToken();
     if (!token) throw new Error('Not authenticated');
     return this.client.send(new GetUserCommand({ AccessToken: token }));
-  }
-
-  async forgotPassword(email: string): Promise<void> {
-    await this.client.send(
-      new ForgotPasswordCommand({
-        ClientId: environment.cognito.clientId,
-        Username: email,
-      }),
-    );
-  }
-
-  async confirmForgotPassword(email: string, code: string, newPassword: string): Promise<void> {
-    await this.client.send(
-      new ConfirmForgotPasswordCommand({
-        ClientId: environment.cognito.clientId,
-        Username: email,
-        ConfirmationCode: code,
-        Password: newPassword,
-      }),
-    );
   }
 
   async signOut(): Promise<void> {

--- a/src/app/core/services/character.service.ts
+++ b/src/app/core/services/character.service.ts
@@ -1,0 +1,24 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { Character } from '../../shared/models/chat.model';
+import { environment } from '../../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class CharacterService {
+  private http = inject(HttpClient);
+
+  private readonly _characters = signal<Character[]>([]);
+  readonly characters = this._characters.asReadonly();
+
+  async load(): Promise<void> {
+    const list = await firstValueFrom(
+      this.http.get<Character[]>(`${environment.apiUrl}/characters`)
+    );
+    this._characters.set(list);
+  }
+
+  getById(id: string): Character | undefined {
+    return this._characters().find((c) => c.id === id);
+  }
+}

--- a/src/app/features/auth/login/login.component.html
+++ b/src/app/features/auth/login/login.component.html
@@ -66,9 +66,6 @@
           <p class="error-msg" [class.invisible]="!(password.invalid && password.touched)">Minimum 8 characters.</p>
         </div>
 
-        <div class="flex justify-end">
-          <a routerLink="/auth/confirm" class="hp-btn-ghost text-xs">Forgot your password?</a>
-        </div>
 
         <button type="submit" [disabled]="loading()" class="hp-btn-primary mt-2">
           @if (loading()) {

--- a/src/app/features/chat/components/chat-sidebar/chat-sidebar.component.html
+++ b/src/app/features/chat/components/chat-sidebar/chat-sidebar.component.html
@@ -19,16 +19,16 @@
 
       <!-- Character picker dropdown -->
       @if (showCharacterPicker()) {
-        <div class="absolute top-full left-0 right-0 mt-1 bg-hp-raised border border-hp-border rounded-lg shadow-xl z-10 overflow-hidden animate-fade-in">
-          @for (key of characterKeys; track key) {
+        <div class="absolute top-full left-0 right-0 mt-1 bg-hp-raised border border-hp-border rounded-lg shadow-xl z-10 animate-fade-in max-h-72 overflow-y-auto">
+          @for (char of characters(); track char.id) {
             <button
-              (click)="newChat(key)"
+              (click)="newChat(char.id)"
               class="w-full flex items-center gap-3 px-4 py-3 hover:bg-hp-surface text-left transition-colors duration-150"
             >
-              <lucide-icon [name]="characters[key].icon" class="w-5 h-5"></lucide-icon>
+              <img [src]="char.icon" [alt]="char.label" class="w-10 h-10 rounded-full object-cover flex-shrink-0" />
               <div>
-                <p class="text-sm text-gray-200 font-medium">{{ characters[key].label }}</p>
-                <p class="text-xs text-hp-muted">{{ characters[key].description }}</p>
+                <p class="text-sm text-gray-200 font-medium">{{ char.label }}</p>
+                <p class="text-xs text-hp-muted">{{ char.description }}</p>
               </div>
             </button>
           }
@@ -56,15 +56,15 @@
         class="group flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-hp-raised transition-all duration-200 mx-1 rounded-lg"
       >
         <!-- Character avatar -->
-        <div class="w-9 h-9 rounded-full bg-hp-border flex items-center justify-center flex-shrink-0">
-          <lucide-icon [name]="getCharacter(chat.character).icon" class="w-5 h-5 text-hp-dark"></lucide-icon>
+        <div class="w-9 h-9 rounded-full bg-hp-border flex items-center justify-center flex-shrink-0 overflow-hidden">
+          <img [src]="getCharacter(chat.character)?.icon" [alt]="getCharacter(chat.character)?.label" class="w-full h-full object-cover" />
         </div>
 
         <!-- Chat info -->
         <div class="flex-1 min-w-0">
           <p class="text-sm text-gray-200 truncate font-medium">{{ chat.title }}</p>
           <p class="text-xs text-hp-muted truncate">
-            {{ getCharacter(chat.character).label }} · {{ formatDate(chat.lastMessageAt) }}
+            {{ getCharacter(chat.character)?.label }} · {{ formatDate(chat.lastMessageAt) }}
           </p>
         </div>
 

--- a/src/app/features/chat/components/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/features/chat/components/chat-sidebar/chat-sidebar.component.ts
@@ -1,9 +1,9 @@
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { LucideAngularModule } from 'lucide-angular';
 import { ChatService } from '../../services/chat.service';
 import { AuthService } from '../../../../core/auth/services/auth.service';
-import { HP_CHARACTERS, HpCharacter } from '../../../../shared/models/chat.model';
+import { CharacterService } from '../../../../core/services/character.service';
 
 @Component({
   selector: 'app-chat-sidebar',
@@ -12,19 +12,20 @@ import { HP_CHARACTERS, HpCharacter } from '../../../../shared/models/chat.model
   templateUrl: './chat-sidebar.component.html',
 })
 export class ChatSidebarComponent {
-  private chatService = inject(ChatService);
-  private authService = inject(AuthService);
-  private router      = inject(Router);
+  private chatService      = inject(ChatService);
+  private authService      = inject(AuthService);
+  private characterService = inject(CharacterService);
+  private router           = inject(Router);
 
   readonly chats      = this.chatService.sortedChats;
   readonly activeChat = this.chatService.activeChat;
-  readonly characters = HP_CHARACTERS;
+  readonly characters = this.characterService.characters;
 
   showCharacterPicker = signal(false);
   deletingId          = signal<string | null>(null);
 
-  newChat(character: HpCharacter = 'dumbledore'): void {
-    const chat = this.chatService.createChat(character);
+  newChat(characterId: string = 'dumbledore'): void {
+    const chat = this.chatService.createChat(characterId);
     this.showCharacterPicker.set(false);
     this.router.navigate(['/chat', chat.id]);
   }
@@ -51,8 +52,8 @@ export class ChatSidebarComponent {
     this.router.navigate(['/auth/login']);
   }
 
-  getCharacter(key: HpCharacter) {
-    return HP_CHARACTERS[key];
+  getCharacter(id: string) {
+    return this.characterService.getById(id);
   }
 
   formatDate(iso: string): string {
@@ -64,6 +65,4 @@ export class ChatSidebarComponent {
     if (diffH < 168) return d.toLocaleDateString('es', { weekday: 'short' });
     return d.toLocaleDateString('es', { day: '2-digit', month: 'short' });
   }
-
-  characterKeys = Object.keys(HP_CHARACTERS) as HpCharacter[];
 }

--- a/src/app/features/chat/components/chat-window/chat-window.component.html
+++ b/src/app/features/chat/components/chat-window/chat-window.component.html
@@ -4,12 +4,12 @@
 
     <!-- Header del chat -->
     <div class="flex items-center gap-3 px-6 py-4 border-b border-hp-border bg-hp-surface/50 backdrop-blur-sm flex-shrink-0">
-      <div class="w-10 h-10 rounded-full bg-hp-border/60 flex items-center justify-center">
-        <lucide-icon [name]="characters[chat.character].icon" class="w-5 h-5 text-hp-gold"></lucide-icon>
+      <div class="w-10 h-10 rounded-full bg-hp-border/60 flex items-center justify-center overflow-hidden">
+        <img [src]="getCharacter(chat.character)?.icon" [alt]="getCharacter(chat.character)?.label" class="w-full h-full object-cover" />
       </div>
       <div>
-        <h2 class="text-sm font-semibold text-gray-100">{{ characters[chat.character].label }}</h2>
-        <p class="text-xs text-hp-muted">{{ characters[chat.character].description }}</p>
+        <h2 class="text-sm font-semibold text-gray-100">{{ getCharacter(chat.character)?.label }}</h2>
+        <p class="text-xs text-hp-muted">{{ getCharacter(chat.character)?.description }}</p>
       </div>
       <div class="ml-auto flex items-center gap-1">
         <lucide-icon name="sparkles" class="w-4 h-4"></lucide-icon>
@@ -22,11 +22,11 @@
 
       @if (messages().length === 0) {
         <div class="flex flex-col items-center justify-center h-full gap-4 text-center animate-fade-in">
-          <lucide-icon [name]="characters[chat.character].icon" class="w-20 h-20 text-hp-gold/40"></lucide-icon>
+          <img [src]="getCharacter(chat.character)?.icon" [alt]="getCharacter(chat.character)?.label" class="w-20 h-20 rounded-full object-cover opacity-40" />
           <div>
-            <h3 class="font-heading text-hp-gold text-lg mb-1">{{ characters[chat.character].label }}</h3>
+            <h3 class="font-heading text-hp-gold text-lg mb-1">{{ getCharacter(chat.character)?.label }}</h3>
             <p class="text-hp-muted text-sm max-w-xs">
-              {{ characters[chat.character].description }}.<br>
+              {{ getCharacter(chat.character)?.description }}.<br>
               Write me something to start!
             </p>
           </div>
@@ -41,8 +41,8 @@
       @if (sending()) {
         <div class="animate-fade-in space-y-2">
           <div class="flex items-end gap-2">
-            <div class="w-8 h-8 rounded-full bg-hp-border/60 flex items-center justify-center flex-shrink-0">
-              <lucide-icon [name]="characters[chat.character].icon" class="w-4 h-4 text-hp-gold"></lucide-icon>
+            <div class="w-8 h-8 rounded-full bg-hp-border/60 flex items-center justify-center flex-shrink-0 overflow-hidden">
+              <img [src]="getCharacter(chat.character)?.icon" [alt]="getCharacter(chat.character)?.label" class="w-full h-full object-cover" />
             </div>
             <div class="bg-hp-surface border border-hp-border rounded-2xl rounded-bl-sm px-4 py-3">
               <div class="flex gap-1 items-center h-4">

--- a/src/app/features/chat/components/chat-window/chat-window.component.ts
+++ b/src/app/features/chat/components/chat-window/chat-window.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, computed, effect, ElementRef, inject, signal, ViewChild } from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
 import { ChatService } from '../../services/chat.service';
-import { HP_CHARACTERS } from '../../../../shared/models/chat.model';
+import { CharacterService } from '../../../../core/services/character.service';
 import { MessageBubbleComponent } from '../message-bubble/message-bubble.component';
 import { ChatInputComponent } from '../chat-input/chat-input.component';
 
@@ -52,11 +52,15 @@ const WAITING_PHRASES = [
 export class ChatWindowComponent implements OnDestroy {
   @ViewChild('messageList') messageList!: ElementRef<HTMLDivElement>;
 
-  private chatService = inject(ChatService);
+  private chatService      = inject(ChatService);
+  private characterService = inject(CharacterService);
 
   readonly activeChat = this.chatService.activeChat;
   readonly sending    = this.chatService.sending;
-  readonly characters = HP_CHARACTERS;
+
+  getCharacter(id: string) {
+    return this.characterService.getById(id);
+  }
   readonly waitingPhrase = signal('');
 
   private phraseInterval: ReturnType<typeof setInterval> | null = null;

--- a/src/app/features/chat/components/message-bubble/message-bubble.component.ts
+++ b/src/app/features/chat/components/message-bubble/message-bubble.component.ts
@@ -1,6 +1,7 @@
-import { Component, input } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
-import { HP_CHARACTERS, HpCharacter, Message } from '../../../../shared/models/chat.model';
+import { Message } from '../../../../shared/models/chat.model';
+import { CharacterService } from '../../../../core/services/character.service';
 
 @Component({
   selector: 'app-message-bubble',
@@ -13,8 +14,8 @@ import { HP_CHARACTERS, HpCharacter, Message } from '../../../../shared/models/c
     >
       <!-- Avatar (solo bot) -->
       @if (message().role === 'assistant') {
-        <div class="w-8 h-8 rounded-full bg-hp-border/60 flex items-center justify-center flex-shrink-0 mb-0.5">
-          <lucide-icon [name]="characters[character()].icon" class="w-4 h-4 text-hp-gold"></lucide-icon>
+        <div class="w-8 h-8 rounded-full bg-hp-border/60 flex-shrink-0 mb-0.5 overflow-hidden">
+          <img [src]="characterIcon()" [alt]="character()" class="w-full h-full object-cover" />
         </div>
       }
 
@@ -31,9 +32,19 @@ import { HP_CHARACTERS, HpCharacter, Message } from '../../../../shared/models/c
         [class.text-gray-100]="message().role === 'assistant'"
         [class.rounded-bl-sm]="message().role === 'assistant'"
       >
-        {{ message().content }}
+        {{ mainText() }}
+
+        @if (sources().length > 0) {
+          <div class="mt-3 pt-3 border-t border-hp-border/50">
+            <p class="text-[10px] text-hp-muted font-heading tracking-wider uppercase mb-1.5">📚 Sources</p>
+            @for (source of sources(); track source) {
+              <p class="text-[10px] text-hp-muted/70 leading-relaxed">• {{ source }}</p>
+            }
+          </div>
+        }
+
         <p
-          class="text-[10px] mt-1 opacity-60"
+          class="text-[10px] mt-2 opacity-60"
           [class.text-right]="message().role === 'user'"
         >
           {{ formatTime(message().createdAt) }}
@@ -43,10 +54,31 @@ import { HP_CHARACTERS, HpCharacter, Message } from '../../../../shared/models/c
   `,
 })
 export class MessageBubbleComponent {
-  message   = input.required<Message>();
-  character = input.required<HpCharacter>();
+  private characterService = inject(CharacterService);
 
-  readonly characters = HP_CHARACTERS;
+  message   = input.required<Message>();
+  character = input.required<string>();
+
+  characterIcon(): string {
+    return this.characterService.getById(this.character())?.icon ?? 'wand-sparkles';
+  }
+
+  mainText(): string {
+    const content = this.message().content;
+    const idx = content.indexOf('\n\n📚 Sources');
+    return idx !== -1 ? content.slice(0, idx).trim() : content;
+  }
+
+  sources(): string[] {
+    const content = this.message().content;
+    const idx = content.indexOf('\n\n📚 Sources');
+    if (idx === -1) return [];
+    return content
+      .slice(idx)
+      .split('\n')
+      .filter(l => l.trim().startsWith('•'))
+      .map(l => l.trim().replace(/^•\s*/, ''));
+  }
 
   formatTime(iso: string): string {
     return new Date(iso).toLocaleTimeString('es', { hour: '2-digit', minute: '2-digit' });

--- a/src/app/features/chat/services/chat.service.ts
+++ b/src/app/features/chat/services/chat.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, computed, inject, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
-import { Chat, HpCharacter, Message, SendMessageResponse } from '../../../shared/models/chat.model';
+import { BackendChatTurnResponse, Chat, HpCharacter, Message } from '../../../shared/models/chat.model';
 import { environment } from '../../../../environments/environment';
 
 const CHATS_KEY    = 'hp_chats';
@@ -85,20 +85,26 @@ export class ChatService {
 
     try {
       const res = await firstValueFrom(
-        this.http.post<SendMessageResponse>(
-          `${environment.apiUrl}/chats/${chatId}/messages`,
-          { content, character: chat.character },
+        this.http.post<BackendChatTurnResponse>(
+          `${environment.apiUrl}/chat/message`,
+          { content, chat_id: chat.backendChatId ?? null, user_id: null, character: chat.character },
         ),
       );
-      this.appendMessage(chatId, res.botMessage);
-    } catch {
-      // Mock while the backend isn't ready
+
+      // Persist backend chat_id for continuity of conversation
+      if (!chat.backendChatId) {
+        const updated = this._chats().map((c) =>
+          c.id === chatId ? { ...c, backendChatId: res.chat_id } : c,
+        );
+        this.persistChats(updated);
+      }
+
       const botMsg: Message = {
-        id:        crypto.randomUUID(),
+        id:        String(res.assistant_message.id),
         chatId,
         role:      'assistant',
-        content:   '🧙‍♂️ The backend is still under construction... but soon I\'ll respond with all the magic of Hogwarts.',
-        createdAt: new Date().toISOString(),
+        content:   res.assistant_message.content,
+        createdAt: res.assistant_message.created_at,
       };
       this.appendMessage(chatId, botMsg);
     } finally {

--- a/src/app/features/quiz/components/quiz-result/quiz-result.component.html
+++ b/src/app/features/quiz/components/quiz-result/quiz-result.component.html
@@ -3,8 +3,8 @@
   <!-- Header -->
   <div class="mb-8">
     <p class="text-hp-muted text-sm mb-2 font-heading tracking-widest uppercase">The Sorting Hat has spoken</p>
-    <div class="w-16 h-16 mx-auto mb-4 text-hp-gold animate-bounce" style="animation-duration: 2s;">
-      <lucide-icon name="zap" class="w-16 h-16"></lucide-icon>
+    <div class="w-24 h-24 mx-auto mb-4 rounded-full overflow-hidden border-2 border-hp-gold/40 animate-bounce" style="animation-duration: 2s;">
+      <img [src]="result().icon" [alt]="result().personaje" class="w-full h-full object-cover" />
     </div>
     <h2 class="font-heading text-hp-gold text-3xl tracking-wide mb-1">{{ result().personaje }}</h2>
   </div>
@@ -61,13 +61,13 @@
       <lucide-icon name="rotate-ccw" class="w-4 h-4"></lucide-icon>
       <span>Retake test</span>
     </button>
-    <a
-      routerLink="/chat"
-      class="flex-1 hp-btn-primary text-center py-3 rounded-lg no-underline flex items-center justify-center gap-2"
+    <button
+      (click)="startChat()"
+      class="flex-1 hp-btn-primary text-center py-3 rounded-lg flex items-center justify-center gap-2"
     >
       <lucide-icon name="message-circle" class="w-4 h-4"></lucide-icon>
       <span>Chat with my character</span>
-    </a>
+    </button>
   </div>
 
 </div>

--- a/src/app/features/quiz/components/quiz-result/quiz-result.component.ts
+++ b/src/app/features/quiz/components/quiz-result/quiz-result.component.ts
@@ -1,7 +1,8 @@
-import { Component, input, output } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Component, inject, input, output } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
 import { LucideAngularModule } from 'lucide-angular';
 import { QuizResult } from '../../../../shared/models/quiz.model';
+import { ChatService } from '../../../chat/services/chat.service';
 
 const CASA_COLORS: Record<string, { bg: string; text: string; border: string; icon: string }> = {
   Gryffindor: { bg: 'bg-red-900/20',    text: 'text-red-400',    border: 'border-red-700/40',    icon: 'shield' },
@@ -17,10 +18,19 @@ const CASA_COLORS: Record<string, { bg: string; text: string; border: string; ic
   templateUrl: './quiz-result.component.html',
 })
 export class QuizResultComponent {
+  private chatService = inject(ChatService);
+  private router      = inject(Router);
+
   result = input.required<QuizResult>();
   retake = output<void>();
 
   getCasaStyle(casa: string) {
     return CASA_COLORS[casa] ?? CASA_COLORS['Gryffindor'];
+  }
+
+  startChat(): void {
+    const characterId = this.result().character_id || 'dumbledore';
+    const chat = this.chatService.createChat(characterId);
+    this.router.navigate(['/chat', chat.id]);
   }
 }

--- a/src/app/shared/models/chat.model.ts
+++ b/src/app/shared/models/chat.model.ts
@@ -1,12 +1,11 @@
-export type HpCharacter = 'dumbledore' | 'hermione' | 'ron' | 'snape' | 'luna';
+export type HpCharacter = string;
 
-export const HP_CHARACTERS: Record<HpCharacter, { label: string; description: string; icon: string }> = {
-  dumbledore: { label: 'Albus Dumbledore', description: 'Wise, philosophical, enigmatic', icon: 'wand-sparkles' },
-  hermione:   { label: 'Hermione Granger', description: 'Precise, intelligent, thorough', icon: 'book-open' },
-  ron:        { label: 'Ron Weasley',       description: 'Casual, funny, loyal', icon: 'shield' },
-  snape:      { label: 'Severus Snape',     description: 'Sarcastic, brilliant, cold', icon: 'moon' },
-  luna:       { label: 'Luna Lovegood',     description: 'Dreamy, peculiar, clever', icon: 'star' },
-};
+export interface Character {
+  id: string;
+  label: string;
+  description: string;
+  icon: string;
+}
 
 export interface Chat {
   id: string;
@@ -14,6 +13,7 @@ export interface Chat {
   character: HpCharacter;
   createdAt: string;
   lastMessageAt: string;
+  backendChatId?: number;
 }
 
 export interface Message {
@@ -24,12 +24,17 @@ export interface Message {
   createdAt: string;
 }
 
-export interface SendMessageRequest {
+export interface BackendMessageOut {
+  id: number;
+  chat_id: number;
+  role: 'user' | 'assistant';
   content: string;
-  character: HpCharacter;
+  trace_id: string | null;
+  created_at: string;
 }
 
-export interface SendMessageResponse {
-  userMessage: Message;
-  botMessage: Message;
+export interface BackendChatTurnResponse {
+  chat_id: number;
+  user_message: BackendMessageOut;
+  assistant_message: BackendMessageOut;
 }

--- a/src/app/shared/models/quiz.model.ts
+++ b/src/app/shared/models/quiz.model.ts
@@ -20,6 +20,8 @@ export interface QuizResult {
   match_percentage: number;
   traits: string[];
   quote: string;
+  icon?: string;
+  character_id?: string;
 }
 
 export const QUIZ_OPTIONS = {


### PR DESCRIPTION

- Add CharacterService to load characters from backend API
- Replace hardcoded HP_CHARACTERS with dynamic GET /characters
- Replace lucide icons with S3 character images across sidebar, chat and bubbles
- Add scroll + larger images to character picker dropdown
- Thread character param through chat flow (send to backend on every message)
- Split message bubble to render Sources section separately with proper styling
- Update quiz to use backend POST /quiz/analyze (LLM-based, DB characters)
- Add icon and character_id to QuizResult model
- Chat with my character button creates chat with matched character
- Remove forgot password flow (not implemented yet)